### PR TITLE
Fix complex

### DIFF
--- a/include/dd.h
+++ b/include/dd.h
@@ -4,8 +4,6 @@
 #include <complex>
 #include <vector>
 #include <random>
-#include <iostream>
-#include <bitset>
 
 
 struct Complex{


### PR DESCRIPTION
I found why the program didn't work well with float. But I think the problem should occur in double too.

variable `n` (memo of norm) should be updated when `r` or `i` are updated by `+-*/`.
Also, it's better to make `r` and `i` private, so that you don't forget update n.

You don't need to merge it, because the code is far from the latest one.