### PR TITLE
Support statevector output in Qiskit

### DIFF
--- a/qdd/bindings.cpp
+++ b/qdd/bindings.cpp
@@ -1,4 +1,6 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/complex.h>
+#include <pybind11/stl.h>
 #include <map>
 #include "dd.h"
 #include "common.h"
@@ -42,6 +44,19 @@ std::pair<vEdge, char> _measureOneCollapsing(vEdge &rootEdge, const Qubit index,
     return std::pair<vEdge, char>(rootEdge, result);
 }
 
+
+
+std::vector<std::complex<double>> _getVector(vEdge &rootEdge){
+    size_t dim;
+    std_complex *vec = rootEdge.getVector(&dim);
+    std::vector<std::complex<double>> result;
+    for (int i = 0; i < dim;i++){
+        std::complex<double> tmp(vec[i].r, vec[i].i);
+        result.push_back(tmp);
+    }
+    return result;
+}
+
 PYBIND11_MODULE(pyQDD, m){
     py::class_<vEdge>(m, "vEdge").def("printVector",&vEdge::printVector).def("printVector_sparse",&vEdge::printVector_sparse);
     py::class_<mEdge>(m, "mEdge").def("printMatrix",&mEdge::printMatrix);
@@ -58,4 +73,5 @@ PYBIND11_MODULE(pyQDD, m){
     // Measure
     m.def("measureAll", _measureAll)
      .def("measureOneCollapsing", _measureOneCollapsing);
+    m.def("getVector", _getVector);
 }

--- a/qdd/circuit_property.py
+++ b/qdd/circuit_property.py
@@ -18,3 +18,4 @@ class CircuitProperty:
 
     stable_final_state: bool
     clbit_final_values: Dict[Clbit, Qubit]
+    store_final_state: bool

--- a/test/python/test_basics.py
+++ b/test/python/test_basics.py
@@ -70,7 +70,8 @@ def test_measure_no_measure():
 
     backend = QddProvider().get_backend()
     job = execute(circ, backend=backend, shots=20, seed_transpiler=50, seed_simulator=80)
-    assert_job_failed(job)
+    statevec = job.result().get_statevector(circ, decimals=3)
+    print(statevec)
 
 
 def test_memory_true():


### PR DESCRIPTION
I wrote a code to support passing statevector to Qiskit interface,
so that some algorithm (e.g. VQE) can speed up the calculation.

* The backend name is changed from `qdd_backend` to `statevector_simulator`.
  * To notify algorithms that the simulator can export statevector.
* The statevector is passed to Qiskit interface only when there's no measure gate.
  * As far as I know, it works correctly with Qiskit algorithm classes.
  * It may need a change in case we find a problem.