### PR TITLE
Enable syntax hilight in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You must prepare the following software.
   * See [the installation manual](https://python-poetry.org/docs/#installing-with-the-official-installer).
 
 You can build QDD as follows.
-```
+```sh
 $ cmake . -DCMAKE_BUILD_TYPE=Release
 $ cmake --build . -j
 $ poetry build
@@ -29,14 +29,14 @@ You can find an installable wheel file in 'dist' directory.
 
 ## Instllation
 Please move to your working directory and install the wheel file created in the build phase.
-```
+```sh
 $ pip install {QDD_DIR}/dist/qdd-XXX.whl
 ```
 
 ## Usage
 QDD works as a Qiskit backend.
 
-```
+```py
 from qiskit import QuantumCircuit, execute
 from qdd import QddBackend, QddProvider
 
@@ -50,7 +50,7 @@ print(qdd_job.result())
 ```
 
 If you need statevector, create the backend as follows.
-```
+```py
 backend = QddProvider().get_backend('statevector_simulator')
 ```
 

--- a/README_MPI.md
+++ b/README_MPI.md
@@ -1,12 +1,12 @@
 ## MPI
 You need to add some options.
-```
+```sh
 $ CC=mpicc CXX=mpicxx Boost_DIR=/usr/lib/x86_64-linux-gnu/cmake cmake -B build -DCMAKE_BUILD_TYPE=Release -DisMPI=ON
 $ cmake --build build -j
 ```
 
 You can run the MPI programs as follows.
-```
+```sh
 $ mpirun -np 4 ./build/test/mpt_test
 $ mpirun -np 4 ./build/test/mpi_test_grover 20
 ```


### PR DESCRIPTION
This pull request enables syntax highlight in README files. Please follow the link below to see what this change means.
https://docs.github.com/en/enterprise-cloud@latest/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks