### PR TITLE
Workflow to upload to PyPI upon a push to main branch

### DIFF
--- a/.github/workflows/publish_to_pypi_ci.yml
+++ b/.github/workflows/publish_to_pypi_ci.yml
@@ -37,16 +37,16 @@ jobs:
                   name: python-package-distributions
                   path: ./wheelhouse/*.whl
 
-
-    publish-to-testpypi:
-      name: Publish Python distribution to TestPyPI
+          
+    publish-to-pypi:
+      name: Publish Python distribution to PyPI
       needs:
       - build
       runs-on: ubuntu-latest
 
       environment:
-        name: testpypi
-        url: https://test.pypi.org/p/qdd
+        name: pypi
+        url: https://pypi.org/p/qdd
       permissions:
         id-token: write  # IMPORTANT: mandatory for trusted publishing
 
@@ -56,7 +56,5 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
-      - name: Publish distribution to TestPyPI
+      - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish_to_pypi_ci.yml
+++ b/.github/workflows/publish_to_pypi_ci.yml
@@ -1,4 +1,4 @@
-name: Publish Python distribution to TestPyPI
+name: Publish Python distribution to PyPI
 
 on:
     push:

--- a/.github/workflows/publish_to_pypi_ci.yml
+++ b/.github/workflows/publish_to_pypi_ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     build:
         name: Build distribution
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
 
         strategy:
             matrix:


### PR DESCRIPTION
- A workflow job to build wheel file and publish it to PyPI on a push to main branch.
- Removed publish to TestPyPI job.