### PR TITLE
cibuidwheelを用いてビルドを行う場合に、ローカルでもpytestが行える様に変更を加えました。

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,6 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-
-
 [project]
 name = "qdd"
 version = "0.2.0"
@@ -36,11 +34,15 @@ classifiers = [
 
 dependencies = [
     "qiskit-aer>=0.13.3",
-]
-
-[project.optional-dependencies]
-develop = [
-    "qiskit-ibm-runtime>=0.21.1"
+    "pytest>=7.2.2",
+    "qiskit-machine-learning[sparse]>=0.6.0",
+    "qiskit-algorithms==0.3.0",
+    "qiskit-finance>=0.4.0",
+    "qiskit-ibm-runtime>=0.21.1",
+    "qiskit-optimization>=0.6.0",
+    "qiskit-nature[pyscf]>=0.7.2",
+    "tweedledum>=1.1.1",
+    "pybind11>=2.10.4",
 ]
 
 # Specifies the path of the root directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ dependencies = [
     "qiskit-aer>=0.13.3",
 ]
 
+[project.optional-dependencies]
+develop = [
+    "qiskit-ibm-runtime>=0.21.1"
+]
 
 # Specifies the path of the root directory
 [tool.setuptools.packages.find]
@@ -45,7 +49,7 @@ where = [""]
 # Excluding redundant directories
 exclude = ["test", "scripts", "_deps", "test*", "test/*", "_deps*", "_deps/*"]
 
-# Include .so to the wheel file. 
+# Include .so to the wheel file.
 [tool.setuptools.package-data]
 "qdd" = ["*.so"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
     "qiskit-ibm-runtime>=0.21.1",
     "qiskit-optimization>=0.6.0",
     "qiskit-nature[pyscf]>=0.7.2",
-    "tweedledum>=1.1.1",
     "pybind11>=2.10.4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ test = [
     "qiskit-ibm-runtime>=0.21.1",
     "qiskit-optimization>=0.6.0",
     "qiskit-nature[pyscf]>=0.7.2",
+    "tweedledum>=1.1.1",
     "pybind11>=2.10.4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=65.0",
-    "wheel",
-    "qiskit-aer>=0.13.3",
-    "pytest>=7.2.2",
-    "qiskit-machine-learning[sparse]>=0.6.0",
-    "qiskit-algorithms==0.3.0",
-    "qiskit-finance>=0.4.0",
-    "qiskit-optimization>=0.6.0",
-    "qiskit-nature[pyscf]>=0.7.2",
-    "tweedledum>=1.1.1",
-    "pybind11>=2.10.4",
-    "auditwheel>=5.4.0",
-    "cmake>=3.26.4"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -63,19 +51,4 @@ exclude = ["test", "scripts", "_deps", "test*", "test/*", "_deps*", "_deps/*"]
 
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux_2_28"
-test-requires = [
-    "setuptools>=65.0",
-    "wheel",
-    "qiskit-aer>=0.13.3",
-    "pytest>=7.2.2",
-    "qiskit-machine-learning[sparse]>=0.6.0",
-    "qiskit-algorithms==0.3.0",
-    "qiskit-finance>=0.4.0",
-    "qiskit-ibm-runtime>=0.21.1",
-    "qiskit-optimization>=0.6.0",
-    "qiskit-nature[pyscf]>=0.7.2",
-    "tweedledum>=1.1.1",
-    "pybind11>=2.10.4",
-    "auditwheel>=5.4.0",
-    "cmake>=3.26.4"
-]
+test-extras = "test"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,12 @@ classifiers = [
 
 dependencies = [
     "qiskit-aer>=0.13.3",
+]
+
+# This command, 'pip install {package-name}[test]',
+# enables you to install the test dependencies along with the main dependencies
+[project.optional-dependencies]
+test = [
     "pytest>=7.2.2",
     "qiskit-machine-learning[sparse]>=0.6.0",
     "qiskit-algorithms==0.3.0",


### PR DESCRIPTION
pyproject.tomlのproject.optional-dependenciesの項目にpytestに必要なライブラリを加えました。
これを元にビルドしたファイルをpip installすると、pytestに必要なライブラリもinstallされます。