### PR TITLE
Feature/support qiskit1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "qiskit~=1.0.0",
+    "qiskit~=1.2.0",
 ]
 
 # This command, 'pip install {package-name}[test]',

--- a/qdd/qdd_backend.py
+++ b/qdd/qdd_backend.py
@@ -162,13 +162,14 @@ class QddBackend(BackendV1):
                 "cu3",
                 "crx",
                 "cry",
-                "crz"  # rotation + 1 control
+                "crz",  # rotation + 1 control
                 # "mcu1", "mcu2", "mcu3","mcu","mcp","mcphase", "mcrx", "mcry", "mcrz", "mcr", # rotation + multi controls
                 "rxx",
                 "ryy",
                 "rzz",
                 "rzx",
                 # "unitary",
+                "reset",
             ]
         ),
         "gates": [],
@@ -695,7 +696,7 @@ class QddBackend(BackendV1):
             for i, qargs, cargs in circ.data:
                 skip = False
                 if i.condition is not None:
-                    classical , val = i.condition
+                    classical, val = i.condition
                     if isinstance(classical, Clbit):
                         if val_cbit[self.get_cID(classical)] != str(int(val)):
                             skip = True

--- a/test/python/helpers/circuit_helper.py
+++ b/test/python/helpers/circuit_helper.py
@@ -21,16 +21,19 @@ def get_simple_circuit(num_qubits: int) -> QuantumCircuit:
     return circ
 
 
-def run_simple_circuit(num_qubits: int, shots: int) -> JobV1:
+def run_simple_circuit(num_qubits: int, shots: int, skip_transpile=False) -> JobV1:
     """Executes a simple circuit that contains no stochastic operations and returns a 'counts' result."""
 
     circ = get_simple_circuit(num_qubits)
     backend = QddProvider().get_backend()
-    job = backend.run(
-        transpile(circuits=circ, backend=backend, seed_transpiler=50),
-        shots=shots,
-        seed_simulator=80,
-    )
+    if skip_transpile:
+        job = backend.run(circ, shots=shots, seed_simulator=80)
+    else:
+        job = backend.run(
+            transpile(circuits=circ, backend=backend, seed_transpiler=50),
+            shots=shots,
+            seed_simulator=80,
+        )
     return job
 
 

--- a/test/python/qiskit_tutorials/advanced_circuits/test_transpiler_passes_and_passmanager.py
+++ b/test/python/qiskit_tutorials/advanced_circuits/test_transpiler_passes_and_passmanager.py
@@ -88,6 +88,7 @@ def test_transpiler_log(caplog):
     log_circ.h(1)
     log_circ.x(1)
     log_circ.cx(0, 1)
+    log_circ.dcx(0, 1)
     log_circ.measure([0, 1], [0, 1])
 
     backend = QddProvider().get_backend()

--- a/test/python/qiskit_tutorials/algorithms/test_iqpe.py
+++ b/test/python/qiskit_tutorials/algorithms/test_iqpe.py
@@ -19,8 +19,6 @@ from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, transpile
 from qdd import QddProvider
 from qdd.qdd_sampler import Sampler
 
-from qiskit.primitives import Sampler as QiskitSampler
-
 
 def x_measurement(qc, qubit, cbit):
     """Measure 'qubit' in the X-basis, and store the result in 'cbit'"""

--- a/test/python/qiskit_tutorials/classical_simulators/test_noise_simulation.py
+++ b/test/python/qiskit_tutorials/classical_simulators/test_noise_simulation.py
@@ -19,13 +19,13 @@ from qiskit import QuantumCircuit, transpile
 from qiskit.quantum_info import Kraus, Operator, SuperOp
 from qiskit_aer import Aer
 from qiskit_aer.noise import NoiseModel, QuantumError, pauli_error
-from qiskit_ibm_runtime.fake_provider import FakeVigo
+from qiskit_ibm_runtime.fake_provider import FakeVigoV2
 
 from qdd import QddBackend, QddProvider
 
 
 def test_noise_simulation():
-    device_backend = FakeVigo()
+    device_backend = FakeVigoV2()
     with pytest.raises(Exception):
         QddBackend.from_backend(device_backend)
 

--- a/test/python/qiskit_tutorials/classical_simulators/test_noise_simulation.py
+++ b/test/python/qiskit_tutorials/classical_simulators/test_noise_simulation.py
@@ -59,7 +59,8 @@ def test_gates_with_labels():
     cx_circ.measure_all()
 
     qdd_backend = QddProvider().get_backend()
-    circ = transpile(cx_circ, backend=qdd_backend, seed_transpiler=50)
+    basis_gates = qdd_backend.configuration().basis_gates
+    circ = transpile(cx_circ, basis_gates=basis_gates, seed_transpiler=50)
     qdd_counts = qdd_backend.run(circ, seed_simulator=80).result().get_counts()
 
     aer_backend = Aer.get_backend("aer_simulator")

--- a/test/python/qiskit_tutorials/operators/test_operator_flow.py
+++ b/test/python/qiskit_tutorials/operators/test_operator_flow.py
@@ -17,7 +17,7 @@ import pytest
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.quantum_info import SparsePauliOp
-from qiskit.primitives import Estimator as QiskitEstimator
+from qiskit.primitives import StatevectorEstimator as QiskitEstimator
 from qiskit.synthesis import SuzukiTrotter
 
 from qdd.qdd_estimator import Estimator
@@ -55,15 +55,13 @@ def test_circuit_sampler():
                 circuits=evo_circ, observables=h2_measurement, parameter_values=time
             )
             .result()
-            .values
+            .values[0]
         )
         print(f"with QDD Estimator : {qdd_value}")
         qiskit_value = (
-            estimator_qiskit.run(
-                circuits=evo_circ, observables=h2_measurement, parameter_values=time
-            )
-            .result()
-            .values
+            estimator_qiskit.run(pubs=[(evo_circ, h2_measurement, time)])
+            .result()[0]
+            .data.evs
         )
         print(f"with Qiskit Estimator : {qiskit_value}")
         assert qiskit_value == pytest.approx(qdd_value, abs=0.02)

--- a/test/python/test_basics.py
+++ b/test/python/test_basics.py
@@ -133,9 +133,10 @@ def test_sv():
         transpile(circuits=circ_h, backend=qdd_backend, seed_transpiler=50),
         seed_simulator=80,
     )
+    global_phase = qdd_job_h.result().results[0].header.global_phase
     sv = qdd_job_h.result().get_statevector()
-    assert cmath.isclose(sv[0], 1 / math.sqrt(2))
-    assert cmath.isclose(sv[1], 1 / math.sqrt(2))
+    assert cmath.isclose(sv[0] * cmath.exp(1j * global_phase), 1 / math.sqrt(2))
+    assert cmath.isclose(sv[1] * cmath.exp(1j * global_phase), 1 / math.sqrt(2))
 
 
 def test_get_counts():

--- a/test/python/test_basics.py
+++ b/test/python/test_basics.py
@@ -43,7 +43,7 @@ def test_num_qubits_2():
 
 def test_num_qubits_max_plus_1():
     max_qubits = QddBackend._DEFAULT_CONFIG["n_qubits"]
-    job = run_simple_circuit(num_qubits=max_qubits + 1, shots=20)
+    job = run_simple_circuit(num_qubits=max_qubits + 1, shots=20, skip_transpile=True)
     assert_job_failed(job)
 
 

--- a/test/python/test_estimator.py
+++ b/test/python/test_estimator.py
@@ -2,7 +2,7 @@
 # https://docs.quantum.ibm.com/api/qiskit/qiskit.primitives.BaseEstimatorV1
 from math import sqrt
 import pytest
-from qiskit.primitives import Estimator as QiskitEstimator
+from qiskit.primitives import StatevectorEstimator as QiskitEstimator
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.quantum_info import SparsePauliOp
 from qdd.qdd_estimator import Estimator
@@ -32,20 +32,22 @@ def test_estimator():
     job = estimator_exact.run([psi1], [H1], [theta1])
     job_result_exact = job.result()
     print(f"The qdd-job without sampling finished with result {job_result_exact}")
-    job = estimator_qiskit.run([psi1], [H1], [theta1])
-    job_result_qiskit = job.result()
+    job = estimator_qiskit.run(pubs=[(psi1, H1, theta1)])
+    job_result_qiskit = job.result()[0]
     print(f"The qiskit-job finished with result {job_result_qiskit}")
     var = job_result.metadata[0]["variance"]
     std = sqrt(var / 4096)
-    assert job_result.values == pytest.approx(
-        job_result_qiskit.values, rel=0.2, abs=std * 6
+    assert job_result.values[0] == pytest.approx(
+        job_result_qiskit.data.evs, rel=0.2, abs=std * 6
     )
     var = job_result_approx.metadata[0]["variance"]
     std = sqrt(var / 4096)
-    assert job_result_approx.values == pytest.approx(
-        job_result_qiskit.values, rel=0.2, abs=std * 6
+    assert job_result_approx.values[0] == pytest.approx(
+        job_result_qiskit.data.evs, rel=0.2, abs=std * 6
     )
-    assert job_result_exact.values == pytest.approx(job_result_qiskit.values, rel=1e-6)
+    assert job_result_exact.values[0] == pytest.approx(
+        job_result_qiskit.data.evs, rel=1e-6
+    )
 
 
 def test_estimator2():
@@ -84,9 +86,8 @@ def test_estimator2():
     )
     job_result_exact = job2.result()
     print(f"The qdd-job without sampling finished with result {job_result_exact}")
-    job2 = estimator_qiskit.run(
-        [psi1, psi2, psi1], [H1, H2, H3], [theta1, theta2, theta3]
-    )
+    pubs = [(psi1, H1, theta1), (psi2, H2, theta2), (psi1, H3, theta3)]
+    job2 = estimator_qiskit.run(pubs=pubs)
     job_result_qiskit = job2.result()
     print(f"The qiskit-job finished with result {job_result_qiskit}")
 
@@ -94,12 +95,15 @@ def test_estimator2():
     stds = [sqrt(var / 4096) for var in vars]
     for i in range(3):
         assert job_result.values[i] == pytest.approx(
-            job_result_qiskit.values[i], rel=0.2, abs=stds[i] * 6
+            job_result_qiskit[i].data.evs, rel=0.2, abs=stds[i] * 6
         )
     vars = [job_result_approx.metadata[i]["variance"] for i in range(3)]
     stds = [sqrt(var / 4096) for var in vars]
     for i in range(3):
         assert job_result_approx.values[i] == pytest.approx(
-            job_result_qiskit.values[i], rel=0.2, abs=stds[i] * 6
+            job_result_qiskit[i].data.evs, rel=0.2, abs=stds[i] * 6
         )
-    assert job_result_exact.values == pytest.approx(job_result_qiskit.values, rel=1e-6)
+    for i in range(3):
+        assert job_result_exact.values[i] == pytest.approx(
+            job_result_qiskit[i].data.evs, rel=1e-6
+        )

--- a/test/python/test_gate.py
+++ b/test/python/test_gate.py
@@ -12,7 +12,8 @@ from qdd.qdd_backend import (
 from qdd.qdd_sampler import Sampler as qdd_sampler
 from qiskit import QuantumCircuit
 import qiskit.circuit.library as qiskit_gates
-from qiskit.primitives import Sampler as qiskit_sampler
+from qiskit.primitives import StatevectorSampler as qiskit_sampler
+from qiskit.result import QuasiDistribution
 import numpy as np
 import math
 import random
@@ -37,20 +38,23 @@ def test_1q_0param_gates():
             qc.h(range(qc_size))
             qc.append(qis_gate, targets)
             qc.measure_all()
-            job_qis = sampler_qiskit.run(
-                circuits=[qc], parameter_values=[[]], parameters=[[]]
-            )
+            pubs = [(qc, [])]
+            job_qis = sampler_qiskit.run(pubs=pubs, shots=1024)
+
             job_qdd = sampler_qdd.run(
                 circuits=[qc], parameter_values=[[]], parameters=[[]]
             )
-            job_result_qis = job_qis.result()
+            qiskit_dists = []
+            for result in job_qis.result():
+                shots = result.metadata["shots"]
+                qiskit_counts = result.data.meas.get_counts()
+                quasidist_dict = {k: v / shots for k, v in qiskit_counts.items()}
+                qiskit_dists.append(QuasiDistribution(quasidist_dict))
             job_result_qdd = job_qdd.result()
-            for dist_qis, dist_qdd in zip(
-                job_result_qis.quasi_dists, job_result_qdd.quasi_dists
-            ):
-                dist_qis = {k: v for k, v in dist_qis.items() if v != 0}
-                dist_qdd = {k: v for k, v in dist_qdd.items() if v != 0}
-                assert dist_qis == pytest.approx(dist_qdd, rel=1e-6)
+            for dist_qis, dist_qdd in zip(qiskit_dists, job_result_qdd.quasi_dists):
+                dist_qis = {k: v for k, v in dist_qis.items() if v >= 0.1}
+                dist_qdd = {k: v for k, v in dist_qdd.items() if v >= 0.1}
+                assert dist_qis == pytest.approx(dist_qdd, rel=0.01)
 
 
 def test_1q_1param_gates():
@@ -67,20 +71,22 @@ def test_1q_1param_gates():
                 qc.h(range(qc_size))
                 qc.append(qis_gate, targets)
                 qc.measure_all()
-                job_qis = sampler_qiskit.run(
-                    circuits=[qc], parameter_values=[[]], parameters=[[]]
-                )
+                pubs = [(qc, [])]
+                job_qis = sampler_qiskit.run(pubs=pubs, shots=1024)
                 job_qdd = sampler_qdd.run(
                     circuits=[qc], parameter_values=[[]], parameters=[[]]
                 )
-                job_result_qis = job_qis.result()
+                qiskit_dists = []
+                for result in job_qis.result():
+                    shots = result.metadata["shots"]
+                    qiskit_counts = result.data.meas.get_counts()
+                    quasidist_dict = {k: v / shots for k, v in qiskit_counts.items()}
+                    qiskit_dists.append(QuasiDistribution(quasidist_dict))
                 job_result_qdd = job_qdd.result()
-                for dist_qis, dist_qdd in zip(
-                    job_result_qis.quasi_dists, job_result_qdd.quasi_dists
-                ):
-                    dist_qis = {k: v for k, v in dist_qis.items() if v != 0}
-                    dist_qdd = {k: v for k, v in dist_qdd.items() if v != 0}
-                    assert dist_qis == pytest.approx(dist_qdd, rel=1e-6)
+                for dist_qis, dist_qdd in zip(qiskit_dists, job_result_qdd.quasi_dists):
+                    dist_qis = {k: v for k, v in dist_qis.items() if v >= 0.1}
+                    dist_qdd = {k: v for k, v in dist_qdd.items() if v >= 0.1}
+                    assert dist_qis == pytest.approx(dist_qdd, rel=0.01)
 
 
 def test_1q_2param_gates():
@@ -96,20 +102,22 @@ def test_1q_2param_gates():
                 qc.h(range(qc_size))
                 qc.append(qis_gate, targets)
                 qc.measure_all()
-                job_qis = sampler_qiskit.run(
-                    circuits=[qc], parameter_values=[[]], parameters=[[]]
-                )
+                pubs = [(qc, [])]
+                job_qis = sampler_qiskit.run(pubs=pubs, shots=1024)
                 job_qdd = sampler_qdd.run(
                     circuits=[qc], parameter_values=[[]], parameters=[[]]
                 )
-                job_result_qis = job_qis.result()
+                qiskit_dists = []
+                for result in job_qis.result():
+                    shots = result.metadata["shots"]
+                    qiskit_counts = result.data.meas.get_counts()
+                    quasidist_dict = {k: v / shots for k, v in qiskit_counts.items()}
+                    qiskit_dists.append(QuasiDistribution(quasidist_dict))
                 job_result_qdd = job_qdd.result()
-                for dist_qis, dist_qdd in zip(
-                    job_result_qis.quasi_dists, job_result_qdd.quasi_dists
-                ):
-                    dist_qis = {k: v for k, v in dist_qis.items() if v != 0}
-                    dist_qdd = {k: v for k, v in dist_qdd.items() if v != 0}
-                    assert dist_qis == pytest.approx(dist_qdd, rel=1e-6)
+                for dist_qis, dist_qdd in zip(qiskit_dists, job_result_qdd.quasi_dists):
+                    dist_qis = {k: v for k, v in dist_qis.items() if v >= 0.1}
+                    dist_qdd = {k: v for k, v in dist_qdd.items() if v >= 0.1}
+                    assert dist_qis == pytest.approx(dist_qdd, rel=0.01)
 
 
 def test_1q_3param_gates():
@@ -126,20 +134,22 @@ def test_1q_3param_gates():
                 qc.h(range(qc_size))
                 qc.append(qis_gate, targets)
                 qc.measure_all()
-                job_qis = sampler_qiskit.run(
-                    circuits=[qc], parameter_values=[[]], parameters=[[]]
-                )
+                pubs = [(qc, [])]
+                job_qis = sampler_qiskit.run(pubs=pubs, shots=1024)
                 job_qdd = sampler_qdd.run(
                     circuits=[qc], parameter_values=[[]], parameters=[[]]
                 )
-                job_result_qis = job_qis.result()
+                qiskit_dists = []
+                for result in job_qis.result():
+                    shots = result.metadata["shots"]
+                    qiskit_counts = result.data.meas.get_counts()
+                    quasidist_dict = {k: v / shots for k, v in qiskit_counts.items()}
+                    qiskit_dists.append(QuasiDistribution(quasidist_dict))
                 job_result_qdd = job_qdd.result()
-                for dist_qis, dist_qdd in zip(
-                    job_result_qis.quasi_dists, job_result_qdd.quasi_dists
-                ):
-                    dist_qis = {k: v for k, v in dist_qis.items() if v != 0}
-                    dist_qdd = {k: v for k, v in dist_qdd.items() if v != 0}
-                    assert dist_qis == pytest.approx(dist_qdd, rel=1e-6)
+                for dist_qis, dist_qdd in zip(qiskit_dists, job_result_qdd.quasi_dists):
+                    dist_qis = {k: v for k, v in dist_qis.items() if v >= 0.1}
+                    dist_qdd = {k: v for k, v in dist_qdd.items() if v >= 0.1}
+                    assert dist_qis == pytest.approx(dist_qdd, rel=0.01)
 
 
 def test_1q_4param_gates():
@@ -157,20 +167,22 @@ def test_1q_4param_gates():
                 qc.h(range(qc_size))
                 qc.append(qis_gate, targets)
                 qc.measure_all()
-                job_qis = sampler_qiskit.run(
-                    circuits=[qc], parameter_values=[[]], parameters=[[]]
-                )
+                pubs = [(qc, [])]
+                job_qis = sampler_qiskit.run(pubs=pubs, shots=1024)
                 job_qdd = sampler_qdd.run(
                     circuits=[qc], parameter_values=[[]], parameters=[[]]
                 )
-                job_result_qis = job_qis.result()
+                qiskit_dists = []
+                for result in job_qis.result():
+                    shots = result.metadata["shots"]
+                    qiskit_counts = result.data.meas.get_counts()
+                    quasidist_dict = {k: v / shots for k, v in qiskit_counts.items()}
+                    qiskit_dists.append(QuasiDistribution(quasidist_dict))
                 job_result_qdd = job_qdd.result()
-                for dist_qis, dist_qdd in zip(
-                    job_result_qis.quasi_dists, job_result_qdd.quasi_dists
-                ):
-                    dist_qis = {k: v for k, v in dist_qis.items() if v != 0}
-                    dist_qdd = {k: v for k, v in dist_qdd.items() if v != 0}
-                    assert dist_qis == pytest.approx(dist_qdd, rel=1e-6)
+                for dist_qis, dist_qdd in zip(qiskit_dists, job_result_qdd.quasi_dists):
+                    dist_qis = {k: v for k, v in dist_qis.items() if v >= 0.1}
+                    dist_qdd = {k: v for k, v in dist_qdd.items() if v >= 0.1}
+                    assert dist_qis == pytest.approx(dist_qdd, rel=0.01)
 
 
 def test_2q_0param_gates():
@@ -183,20 +195,22 @@ def test_2q_0param_gates():
             qc.h(range(qc_size))
             qc.append(qis_gate, targets)
             qc.measure_all()
-            job_qis = sampler_qiskit.run(
-                circuits=[qc], parameter_values=[[]], parameters=[[]]
-            )
+            pubs = [(qc, [])]
+            job_qis = sampler_qiskit.run(pubs=pubs, shots=1024)
             job_qdd = sampler_qdd.run(
                 circuits=[qc], parameter_values=[[]], parameters=[[]]
             )
-            job_result_qis = job_qis.result()
+            qiskit_dists = []
+            for result in job_qis.result():
+                shots = result.metadata["shots"]
+                qiskit_counts = result.data.meas.get_counts()
+                quasidist_dict = {k: v / shots for k, v in qiskit_counts.items()}
+                qiskit_dists.append(QuasiDistribution(quasidist_dict))
             job_result_qdd = job_qdd.result()
-            for dist_qis, dist_qdd in zip(
-                job_result_qis.quasi_dists, job_result_qdd.quasi_dists
-            ):
-                dist_qis = {k: v for k, v in dist_qis.items() if v != 0}
-                dist_qdd = {k: v for k, v in dist_qdd.items() if v != 0}
-                assert dist_qis == pytest.approx(dist_qdd, rel=1e-6)
+            for dist_qis, dist_qdd in zip(qiskit_dists, job_result_qdd.quasi_dists):
+                dist_qis = {k: v for k, v in dist_qis.items() if v >= 0.1}
+                dist_qdd = {k: v for k, v in dist_qdd.items() if v >= 0.1}
+                assert dist_qis == pytest.approx(dist_qdd, rel=0.01)
 
 
 def test_2q_1param_gates():
@@ -211,20 +225,22 @@ def test_2q_1param_gates():
                 qc.h(range(qc_size))
                 qc.append(qis_gate, targets)
                 qc.measure_all()
-                job_qis = sampler_qiskit.run(
-                    circuits=[qc], parameter_values=[[]], parameters=[[]]
-                )
+                pubs = [(qc, [])]
+                job_qis = sampler_qiskit.run(pubs=pubs, shots=1024)
                 job_qdd = sampler_qdd.run(
                     circuits=[qc], parameter_values=[[]], parameters=[[]]
                 )
-                job_result_qis = job_qis.result()
+                qiskit_dists = []
+                for result in job_qis.result():
+                    shots = result.metadata["shots"]
+                    qiskit_counts = result.data.meas.get_counts()
+                    quasidist_dict = {k: v / shots for k, v in qiskit_counts.items()}
+                    qiskit_dists.append(QuasiDistribution(quasidist_dict))
                 job_result_qdd = job_qdd.result()
-                for dist_qis, dist_qdd in zip(
-                    job_result_qis.quasi_dists, job_result_qdd.quasi_dists
-                ):
-                    dist_qis = {k: v for k, v in dist_qis.items() if v != 0}
-                    dist_qdd = {k: v for k, v in dist_qdd.items() if v != 0}
-                    assert dist_qis == pytest.approx(dist_qdd, rel=1e-6)
+                for dist_qis, dist_qdd in zip(qiskit_dists, job_result_qdd.quasi_dists):
+                    dist_qis = {k: v for k, v in dist_qis.items() if v >= 0.1}
+                    dist_qdd = {k: v for k, v in dist_qdd.items() if v >= 0.1}
+                    assert dist_qis == pytest.approx(dist_qdd, rel=0.01)
 
 
 def test_unitary():
@@ -237,17 +253,19 @@ def test_unitary():
             qc.h(range(qc_size))
             qc.append(qiskit_gates.UnitaryGate(random_matrix), targets)
             qc.measure_all()
-            job_qis = sampler_qiskit.run(
-                circuits=[qc], parameter_values=[[]], parameters=[[]]
-            )
+            pubs = [(qc, [])]
+            job_qis = sampler_qiskit.run(pubs=pubs, shots=1024)
             job_qdd = sampler_qdd.run(
                 circuits=[qc], parameter_values=[[]], parameters=[[]]
             )
-            job_result_qis = job_qis.result()
+            qiskit_dists = []
+            for result in job_qis.result():
+                shots = result.metadata["shots"]
+                qiskit_counts = result.data.meas.get_counts()
+                quasidist_dict = {k: v / shots for k, v in qiskit_counts.items()}
+                qiskit_dists.append(QuasiDistribution(quasidist_dict))
             job_result_qdd = job_qdd.result()
-            for dist_qis, dist_qdd in zip(
-                job_result_qis.quasi_dists, job_result_qdd.quasi_dists
-            ):
-                dist_qis = {k: v for k, v in dist_qis.items() if v != 0}
-                dist_qdd = {k: v for k, v in dist_qdd.items() if v != 0}
-                assert dist_qis == pytest.approx(dist_qdd, rel=1e-6)
+            for dist_qis, dist_qdd in zip(qiskit_dists, job_result_qdd.quasi_dists):
+                dist_qis = {k: v for k, v in dist_qis.items() if v >= 0.1}
+                dist_qdd = {k: v for k, v in dist_qdd.items() if v >= 0.1}
+                assert dist_qis == pytest.approx(dist_qdd, rel=0.01)

--- a/test/python/test_sampler.py
+++ b/test/python/test_sampler.py
@@ -1,11 +1,13 @@
 # The code in this file has been written using part of the code in the Qiskit API documentation.
 # https://docs.quantum.ibm.com/api/qiskit/qiskit.primitives.BaseSamplerV1
 import pytest
-from qiskit.primitives import Sampler as QiskitSampler
+from qiskit.primitives import StatevectorSampler as QiskitSampler
 from qiskit import QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes
+from qiskit.result import QuasiDistribution
 
 from qdd.qdd_sampler import Sampler
+
 
 def test_sampler():
     # a Bell circuit
@@ -16,7 +18,9 @@ def test_sampler():
 
     # initialization of the sampler
     sampler_qiskit = QiskitSampler()
-    sampler = Sampler(run_options={"shots": 4096}) # if shots is default value, tests sometimes fail because precision is not enough
+    sampler = Sampler(
+        run_options={"shots": 4096}
+    )  # if shots is default value, tests sometimes fail because precision is not enough
     sampler_exact = Sampler(run_options={"shots": None})
 
     # Sampler runs a job on the Bell circuit
@@ -24,23 +28,36 @@ def test_sampler():
     job_result = job.result()
     print("QDD Sampler with shots:")
     print([q.binary_probabilities() for q in job_result.quasi_dists])
-    job_exact = sampler_exact.run(circuits=[bell], parameter_values=[[]], parameters=[[]])
+    job_exact = sampler_exact.run(
+        circuits=[bell], parameter_values=[[]], parameters=[[]]
+    )
     job_result_exact = job_exact.result()
     print("QDD Sampler without shots:")
     print([q.binary_probabilities() for q in job_result_exact.quasi_dists])
-    job_qiskit = sampler_qiskit.run(circuits=[bell], parameter_values=[[]], parameters=[[]])
-    job_result_qiskit = job_qiskit.result()
+    pubs = [(bell, [])]
+    job_qiskit = sampler_qiskit.run(pubs=pubs, shots=4096)
+    qiskit_dists = []
+    for result in job_qiskit.result():
+        shots = result.metadata["shots"]
+        qiskit_counts = result.data.meas.get_counts()
+        quasidist_dict = {k: v / shots for k, v in qiskit_counts.items()}
+        qiskit_dists.append(QuasiDistribution(quasidist_dict))
     print("Qiskit Sampler:")
-    print([q.binary_probabilities() for q in job_result_qiskit.quasi_dists])
-    for dist,dist_exact,dist_qiskit in zip(job_result.quasi_dists, job_result_exact.quasi_dists, job_result_qiskit.quasi_dists):
+    print([q.binary_probabilities() for q in qiskit_dists])
+    for dist, dist_exact, dist_qiskit in zip(
+        job_result.quasi_dists,
+        job_result_exact.quasi_dists,
+        qiskit_dists,
+    ):
         # delete 0s from the distribution
         dist = {k: v for k, v in dist.items() if v != 0}
         dist_exact = {k: v for k, v in dist_exact.items() if v != 0}
-        assert dist == pytest.approx(dist_qiskit,rel=0.2,abs=0.01)
-        assert dist_exact == pytest.approx(dist_qiskit,rel=1e-6)
+        assert dist == pytest.approx(dist_qiskit, rel=0.2, abs=0.01)
+        assert dist_exact == pytest.approx(dist_qiskit, rel=0.2, abs=0.01)
+
 
 def test_sampler_param():
-    
+
     # two parameterized circuits
     pqc = RealAmplitudes(num_qubits=2, reps=2)
     pqc.measure_all()
@@ -49,34 +66,46 @@ def test_sampler_param():
 
     theta1 = [0, 1, 1, 2, 3, 5]
     theta2 = [0, 1, 2, 3, 4, 5, 6, 7]
-    
+
     # initialization of the sampler
     sampler_qiskit = QiskitSampler()
-    sampler = Sampler(run_options={"shots": 4096}) # if shots is default value, tests sometimes fail because precision is not enough
+    sampler = Sampler(
+        run_options={"shots": 4096}
+    )  # if shots is default value, tests sometimes fail because precision is not enough
     sampler_exact = Sampler(run_options={"shots": None})
 
     # Sampler runs a job on the parameterized circuits
     job2 = sampler.run(
         circuits=[pqc, pqc2],
         parameter_values=[theta1, theta2],
-        parameters=[pqc.parameters, pqc2.parameters])
+        parameters=[pqc.parameters, pqc2.parameters],
+    )
     job_result = job2.result()
     print("QDD Sampler with shots:")
     print([q.binary_probabilities() for q in job_result.quasi_dists])
     job2_exact = sampler_exact.run(
         circuits=[pqc, pqc2],
         parameter_values=[theta1, theta2],
-        parameters=[pqc.parameters, pqc2.parameters])
+        parameters=[pqc.parameters, pqc2.parameters],
+    )
     job_result_exact = job2_exact.result()
     print("QDD Sampler without shots:")
     print([q.binary_probabilities() for q in job_result_exact.quasi_dists])
-    job2_qiskit = sampler_qiskit.run(
-        circuits=[pqc, pqc2],
-        parameter_values=[theta1, theta2],
-        parameters=[pqc.parameters, pqc2.parameters])
+    pubs = [(pqc, theta1), (pqc2, theta2)]
+    job2_qiskit = sampler_qiskit.run(pubs=pubs, shots=4096)
     job_result_qiskit = job2_qiskit.result()
+    qiskit_dists = []
+    for result in job_result_qiskit:
+        shots = result.metadata["shots"]
+        qiskit_counts = result.data.meas.get_counts()
+        quasidist_dict = {k: v / shots for k, v in qiskit_counts.items()}
+        qiskit_dists.append(QuasiDistribution(quasidist_dict))
     print("Qiskit Sampler:")
-    print([q.binary_probabilities() for q in job_result_qiskit.quasi_dists])
-    for dist,dist_exact,dist_qiskit in zip(job_result.quasi_dists, job_result_exact.quasi_dists, job_result_qiskit.quasi_dists):
-        assert dist == pytest.approx(dist_qiskit,rel=0.2,abs=0.01)
-        assert dist_exact == pytest.approx(dist_qiskit,rel=1e-6)
+    print([q.binary_probabilities() for q in qiskit_dists])
+    for dist, dist_exact, dist_qiskit in zip(
+        job_result.quasi_dists,
+        job_result_exact.quasi_dists,
+        qiskit_dists,
+    ):
+        assert dist == pytest.approx(dist_qiskit, rel=0.2, abs=0.01)
+        assert dist_exact == pytest.approx(dist_qiskit, rel=0.2, abs=0.01)


### PR DESCRIPTION
・global phaseに関しての変更はhゲートがbasis gatesに入っている限り考慮しなくてもよいですが、コード修正中にhゲートを外した時にエラーになったので一応変更しました。
・max_num_qubitsに関してはtranspile()内でもエラーを出すようになっていたので、テストでは迂回するようにしました。
・basis translatorがbasis_gates内のgateに対しては早期リターンで実行されないようになっていたので、qdd_bakcendのbasis_gatesに無いgateをテスト回路に追加しました。
・テストコード中でqdd側を変更せずにアップグレードできるqiskit関数を変更しました。
・unitary gateがある回路に対するtranspile()に渡す引数をbackendからbasis_gatesに変更しました。ほかのtranpile()に関しては次のプルリクでbackendV2への移行で解決します。
