### PR TITLE
ci: use actions/download-artifact@v4 (v3 deprecated)

### DIFF
--- a/.github/workflows/publish_to_pypi_ci.yml
+++ b/.github/workflows/publish_to_pypi_ci.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: dist/
       - name: Publish distribution to PyPI


### PR DESCRIPTION
actions/download-artifact の v3 が非推奨で自動失敗対象となったため、ワークフローを v4 に更新します。